### PR TITLE
Stack References Project url

### DIFF
--- a/azure-typescript/PRE-CLASS-NOTES.md
+++ b/azure-typescript/PRE-CLASS-NOTES.md
@@ -33,7 +33,4 @@ azure-typescript-workshop
 9. `pulumi new https://github.com/pulumi/training/tree/main/azure-typescript/3_component-resources`
 10. `cd ..`
 11. `mkdir stack-references && cd stack-references`
-12. `pulumi new https://github.com/pulumi/training/tree/main/azure-typescript/3_component-resources`
-
-
-
+12. `pulumi new https://github.com/pulumi/training/tree/main/azure-typescript/4_stack-references`


### PR DESCRIPTION
Updated the URL for the stack-references project from `pulumi new https://github.com/pulumi/training/tree/main/azure-typescript/3_component-resources` to `pulumi new https://github.com/pulumi/training/tree/main/azure-typescript/4_stack-references`.

It was initally the same as the component-resources project. Assuming this is incorrect, as the installation failed using `pulumi new https://github.com/pulumi/training/tree/main/azure-typescript/3_component-resources` in the `stack-references` directory.